### PR TITLE
Export DebugRendererError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,5 @@ mod text_renderer;
 mod bitmap_font;
 mod utils;
 
-pub use debug_renderer::DebugRenderer;
+pub use debug_renderer::{DebugRenderer, DebugRendererError};
 pub use bitmap_font::BitmapFont;


### PR DESCRIPTION
Sorry, haven't checked it in previous PR.
DebugRendererError needs to be reexported in order to let end-user actually use it.
