### PR TITLE
Gfx text update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ Library for batched renderering of lines and text in 3D space, using [gfx-rs](ht
 ```rust
 // Initializing...
 
+// Create gfx_text::Renderer to be used by the DebugRenderer
+let text_renderer = {
+    let factory = piston_window.device.borrow_mut().spawn_factory(); // gfx::Factory
+    gfx_text::new(factory).unwrap() // can optionally configure text renderer here (font, color)
+};
+
 let mut debug_renderer = DebugRenderer::new(
-	factory // a gfx::Factory, to be owned by DebugRenderer
+    piston_window.device.borrow_mut().spawn_factory(), // gfx::Factory
+    text_renderer,
 	64, // Initial size of vertex buffers
 ).ok().unwrap();
 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -3,6 +3,7 @@ extern crate shader_version;
 extern crate sdl2;
 extern crate sdl2_window;
 extern crate gfx;
+extern crate gfx_text;
 extern crate camera_controllers;
 extern crate vecmath;
 extern crate gfx_debug_draw;
@@ -48,8 +49,16 @@ fn main() {
 
     let piston_window = piston_window::PistonWindow::new(window, piston_window::empty_app());
 
-    let factory = piston_window.device.borrow_mut().spawn_factory();
-    let mut debug_renderer = DebugRenderer::new(factory, 64).ok().unwrap();
+    let mut debug_renderer = {
+        let factory = piston_window.device.borrow_mut().spawn_factory();
+
+        let text_renderer = {
+            let factory = piston_window.device.borrow_mut().spawn_factory();
+            gfx_text::new(factory).unwrap()
+        };
+
+        DebugRenderer::new(factory, text_renderer, 64).ok().unwrap()
+    };
 
     let model = mat4_id();
     let mut projection = CameraPerspective {

--- a/src/debug_renderer.rs
+++ b/src/debug_renderer.rs
@@ -31,7 +31,7 @@ impl From<gfx_text::Error> for DebugRendererError {
 
 pub struct DebugRenderer<R: gfx::Resources, F: Factory<R>> {
     line_renderer: LineRenderer<R>,
-    text_renderer: gfx_text::Renderer<R>,
+    text_renderer: gfx_text::Renderer<R, F>,
     factory: F,
 }
 
@@ -39,12 +39,12 @@ impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {
 
     pub fn new (
         factory: F,
+        text_renderer: gfx_text::Renderer<R, F>,
         initial_buffer_size: usize,
     ) -> Result<DebugRenderer<R, F>, DebugRendererError> {
 
         let mut factory = factory;
         let line_renderer = try!(LineRenderer::new(&mut factory, initial_buffer_size));
-        let text_renderer = gfx_text::new(&mut factory).unwrap();
 
         Ok(DebugRenderer {
             line_renderer: line_renderer,
@@ -81,7 +81,7 @@ impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {
         projection: [[f32; 4]; 4],
     ) -> Result<(), DebugRendererError> {
         try!(self.line_renderer.render(stream, &mut self.factory, projection));
-        try!(self.text_renderer.draw_end_at(&mut self.factory, stream, projection));
+        try!(self.text_renderer.draw_end_at(stream, projection));
         Ok(())
     }
 }


### PR DESCRIPTION
gfx_text::Renderer now needs it's own gfx::Factory instance.

Not sure how to spawn new factories within DebugRenderer without assuming gfx_device_gl, so seemed easiest to instantiate the gfx_text::Renderer outside the constructor and pass it in. This also makes it possible to configure the text renderer (eg font, color) before passing it into the DebugRenderer.
