### PR TITLE
Added 'draw_marker', CommandQueue singleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ git = "https://github.com/gfx-rs/gfx-rs"
 [dependencies.gfx_text]
 git = "https://github.com/PistonDevelopers/gfx_text"
 
-###### For example ###########################
-
-[dev-dependencies.vecmath]
+[dependencies.vecmath]
 git = "https://github.com/PistonDevelopers/vecmath"
+
+###### For example ###########################
 
 [dev-dependencies.piston]
 git = "https://github.com/PistonDevelopers/piston"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,36 +4,20 @@ name = "gfx_debug_draw"
 version = "0.2.0"
 authors = ["Steve Jahns <s.t.jahns@gmail.com>"]
 
-[dependencies.gfx]
-git = "https://github.com/gfx-rs/gfx-rs"
-
-[dependencies.gfx_text]
-git = "https://github.com/PistonDevelopers/gfx_text"
-
-[dependencies.vecmath]
-git = "https://github.com/PistonDevelopers/vecmath"
+[dependencies]
+gfx = "0.6.*"
+gfx_text = "0.2.*"
+vecmath = "*"
 
 ###### For example ###########################
 
-[dev-dependencies.piston]
-git = "https://github.com/PistonDevelopers/piston"
-
-[dev-dependencies.shader_version]
-git = "https://github.com/PistonDevelopers/shader_version"
-
-[dev-dependencies.camera_controllers]
-git = "https://github.com/pistondevelopers/camera_controllers"
-
-[dev-dependencies.sdl2]
-git = "https://github.com/AngryLawyer/rust-sdl2"
-
-[dev-dependencies.pistoncore-sdl2_window]
-git = "https://github.com/PistonDevelopers/sdl2_window"
-
-[dev-dependencies.gfx_device_gl]
-git = "https://github.com/gfx-rs/gfx_device_gl"
-
-[dev-dependencies.piston_window]
-git = "https://github.com/pistondevelopers/piston_window"
+[dev-dependencies]
+piston = "0.1.*"
+piston_window = "0.0.*"
+sdl2 = "0.4.*"
+pistoncore-sdl2_window = "0.0.*"
+gfx_device_gl = "0.4.*"
+shader_version = "0.0.*"
+camera_controllers = "0.0.*"
 
 ###############################################

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ debug_renderer.draw_text_on_screen(
 	[1.0, 0.4, 0.4, 0.7] // Text color
 );
 
+// Draw a yellow position marker
+debug_renderer.draw_marker(
+    [1.0, 2.0, 3.0],  // Position
+    0.5, // Size
+    [1.0, 1.0, 0.0, 1.0] // Color
+);
+
 // Render the final batch of all lines and text currently present in the vertex/index buffers
 
 debug_renderer.render(
@@ -53,4 +60,17 @@ debug_renderer.render(
 	camera_projection, // Current camera projection matrix
 );
 
+```
+
+Draw commands can also be queued up with static methods, which is useful when you want to debug
+something in a context where you have no access to the DebugRenderer instance.
+
+```rust
+fn foobar() {
+   ...
+   let x: Vector3<f32> = some_expression;
+   // Visually debug the value of `x` with a red position marker:
+   gfx_debug_draw::draw_marker(x, 1.0, [1.0, 0.0, 0.0, 1.0]);
+   ...
+}
 ```

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -127,6 +127,18 @@ fn main() {
                 [0.0, 0.0, 1.0, 1.0],
             );
 
+            debug_renderer.draw_marker(
+                [5.0, 5.0, 5.0],
+                1.0,
+                [0.0, 0.0, 1.0, 1.0],
+            );
+
+            // Alternate usage:
+            gfx_debug_draw::draw_line([0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]);
+            gfx_debug_draw::draw_text_on_screen("Stuff", [10, 10], [0.0, 0.0, 1.0, 1.0]);
+            gfx_debug_draw::draw_text_at_position("Things", [2.0, 2.0, 2.0], [1.0, 1.0, 1.0, 1.0]);
+            gfx_debug_draw::draw_marker([-2.0, -2.0, -2.0], 0.5, [1.0, 1.0, 0.0, 1.0]);
+
             if let Err(e) = debug_renderer.render(stream, camera_projection) {
                 println!("{:?}", e);
             }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -50,14 +50,10 @@ fn main() {
     let piston_window = piston_window::PistonWindow::new(window, piston_window::empty_app());
 
     let mut debug_renderer = {
-        let factory = piston_window.device.borrow_mut().spawn_factory();
-
         let text_renderer = {
-            let factory = piston_window.device.borrow_mut().spawn_factory();
-            gfx_text::new(factory).unwrap()
+            gfx_text::new(piston_window.factory.borrow().clone()).unwrap()
         };
-
-        DebugRenderer::new(factory, text_renderer, 64).ok().unwrap()
+        DebugRenderer::new(piston_window.factory.borrow().clone(), text_renderer, 64).ok().unwrap()
     };
 
     let model = mat4_id();

--- a/src/debug_renderer.rs
+++ b/src/debug_renderer.rs
@@ -1,12 +1,74 @@
-use std::sync::{Arc,Mutex,Once,ONCE_INIT};
 use std::collections::VecDeque;
 use std::mem;
+use std::sync::{Arc,Mutex,Once,ONCE_INIT};
 use gfx;
 use gfx::traits::*;
 use gfx_text;
 use vecmath::*;
 
 use line_renderer::LineRenderer;
+
+type WorldPosition = [f32; 3];
+type ScreenPosition = [i32; 2];
+type Color = [f32; 4];
+type Size = f32;
+
+enum DrawCommand {
+    DrawLine(WorldPosition, WorldPosition, Color),
+    DrawMarker(WorldPosition, Size, Color),
+    DrawScreenText(String, ScreenPosition, Color),
+    DrawWorldText(String, WorldPosition, Color),
+}
+
+#[derive(Clone)]
+struct CommandQueue {
+    queue: Arc<Mutex<VecDeque<DrawCommand>>>
+}
+
+static mut command_queue_singleton: *const CommandQueue = 0 as *const CommandQueue;
+
+impl CommandQueue {
+
+    fn push_back(&mut self, command: DrawCommand) {
+        let mut queue = self.queue.lock().unwrap();
+        queue.push_back(command);
+    }
+
+    fn pop_front(&mut self) -> Option<DrawCommand> {
+        let mut queue = self.queue.lock().unwrap();
+        queue.pop_front()
+    }
+
+    fn instance() -> CommandQueue {
+        static ONCE: Once = ONCE_INIT;
+
+        unsafe {
+            ONCE.call_once(|| {
+                let command_queue = CommandQueue {
+                    queue: Arc::new(Mutex::new(VecDeque::<DrawCommand>::new()))
+                };
+                command_queue_singleton = mem::transmute(Box::new(command_queue));
+            });
+            (*command_queue_singleton).clone()
+        }
+    }
+}
+
+pub fn draw_marker(position: [f32; 3], size: f32, color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawMarker(position, size, color));
+}
+
+pub fn draw_line(start: [f32; 3], end: [f32; 3], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawLine(start, end, color));
+}
+
+pub fn draw_text_on_screen(text: &str, screen_position: [i32; 2], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawScreenText(text.to_string(), screen_position, color));
+}
+
+pub fn draw_text_at_position(text: &str, position: [f32; 3], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawWorldText(text.to_string(), position, color));
+}
 
 #[derive(Debug)]
 pub enum DebugRendererError {
@@ -39,65 +101,25 @@ pub struct DebugRenderer<R: gfx::Resources, F: Factory<R>> {
     factory: F,
 }
 
-type WorldPosition = [f32; 3];
-type ScreenPosition = [i32; 2];
-type Color = [f32; 4];
-type Size = f32;
+impl<R: gfx::Resources, F: Factory<R>> Drop for DebugRenderer<R, F> {
 
-enum DrawCommand {
-    DrawLine(WorldPosition, WorldPosition, Color),
-    DrawMarker(WorldPosition, Size, Color),
-    DrawScreenText(String, ScreenPosition, Color),
-    DrawWorldText(String, WorldPosition, Color),
-}
-
-#[derive(Clone)]
-struct CommandQueue {
-    queue: Arc<Mutex<VecDeque<DrawCommand>>>
-}
-
-impl CommandQueue {
-
-    fn push_back(&mut self, command: DrawCommand) {
-        let mut queue = self.queue.lock().unwrap();
-        queue.push_back(command);
-    }
-
-    fn pop_front(&mut self) -> Option<DrawCommand> {
-        let mut queue = self.queue.lock().unwrap();
-        queue.pop_front()
-    }
-
-    fn instance() -> CommandQueue {
-        static mut command_queue_singleton: *const CommandQueue = 0 as *const CommandQueue;
-        static ONCE: Once = ONCE_INIT;
-
+    /// Frees memory alocated for the command queue singleton
+    ///
+    /// Could be leaky if a `gfx_debug_draw::draw_*` method is called without
+    /// ever instantiating a DebugRenderer. Also could be problematic if there
+    /// are multiple DebugRenderer instances.
+    ///
+    /// Should look into freeing memory on `rt::at_exit` if/when that becomes stable
+    /// See http://stackoverflow.com/questions/27791532/how-do-i-create-a-global-mutable-singleton
+    fn drop(&mut self) {
         unsafe {
-            ONCE.call_once(|| {
-                let command_queue = CommandQueue {
-                    queue: Arc::new(Mutex::new(VecDeque::<DrawCommand>::new()))
-                };
-                command_queue_singleton = mem::transmute(Box::new(command_queue));
-            });
-            (*command_queue_singleton).clone()
+            if command_queue_singleton != 0 as *const _ {
+                let command_queue: Box<CommandQueue> = mem::transmute(command_queue_singleton);
+                drop(command_queue);
+                command_queue_singleton = 0 as *const _;
+            }
         }
     }
-}
-
-pub fn draw_marker(position: [f32; 3], size: f32, color: [f32; 4]) {
-    CommandQueue::instance().push_back(DrawCommand::DrawMarker(position, size, color));
-}
-
-pub fn draw_line(start: [f32; 3], end: [f32; 3], color: [f32; 4]) {
-    CommandQueue::instance().push_back(DrawCommand::DrawLine(start, end, color));
-}
-
-pub fn draw_text_on_screen(text: &str, screen_position: [i32; 2], color: [f32; 4]) {
-    CommandQueue::instance().push_back(DrawCommand::DrawScreenText(text.to_string(), screen_position, color));
-}
-
-pub fn draw_text_at_position(text: &str, position: [f32; 3], color: [f32; 4]) {
-    CommandQueue::instance().push_back(DrawCommand::DrawWorldText(text.to_string(), position, color));
 }
 
 impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {

--- a/src/debug_renderer.rs
+++ b/src/debug_renderer.rs
@@ -1,8 +1,12 @@
-use line_renderer::LineRenderer;
-
+use std::sync::{Arc,Mutex,Once,ONCE_INIT};
+use std::collections::VecDeque;
+use std::mem;
 use gfx;
 use gfx::traits::*;
 use gfx_text;
+use vecmath::*;
+
+use line_renderer::LineRenderer;
 
 #[derive(Debug)]
 pub enum DebugRendererError {
@@ -35,6 +39,67 @@ pub struct DebugRenderer<R: gfx::Resources, F: Factory<R>> {
     factory: F,
 }
 
+type WorldPosition = [f32; 3];
+type ScreenPosition = [i32; 2];
+type Color = [f32; 4];
+type Size = f32;
+
+enum DrawCommand {
+    DrawLine(WorldPosition, WorldPosition, Color),
+    DrawMarker(WorldPosition, Size, Color),
+    DrawScreenText(String, ScreenPosition, Color),
+    DrawWorldText(String, WorldPosition, Color),
+}
+
+#[derive(Clone)]
+struct CommandQueue {
+    queue: Arc<Mutex<VecDeque<DrawCommand>>>
+}
+
+impl CommandQueue {
+
+    fn push_back(&mut self, command: DrawCommand) {
+        let mut queue = self.queue.lock().unwrap();
+        queue.push_back(command);
+    }
+
+    fn pop_front(&mut self) -> Option<DrawCommand> {
+        let mut queue = self.queue.lock().unwrap();
+        queue.pop_front()
+    }
+
+    fn instance() -> CommandQueue {
+        static mut command_queue_singleton: *const CommandQueue = 0 as *const CommandQueue;
+        static ONCE: Once = ONCE_INIT;
+
+        unsafe {
+            ONCE.call_once(|| {
+                let command_queue = CommandQueue {
+                    queue: Arc::new(Mutex::new(VecDeque::<DrawCommand>::new()))
+                };
+                command_queue_singleton = mem::transmute(Box::new(command_queue));
+            });
+            (*command_queue_singleton).clone()
+        }
+    }
+}
+
+pub fn draw_marker(position: [f32; 3], size: f32, color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawMarker(position, size, color));
+}
+
+pub fn draw_line(start: [f32; 3], end: [f32; 3], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawLine(start, end, color));
+}
+
+pub fn draw_text_on_screen(text: &str, screen_position: [i32; 2], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawScreenText(text.to_string(), screen_position, color));
+}
+
+pub fn draw_text_at_position(text: &str, position: [f32; 3], color: [f32; 4]) {
+    CommandQueue::instance().push_back(DrawCommand::DrawWorldText(text.to_string(), position, color));
+}
+
 impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {
 
     pub fn new (
@@ -55,6 +120,20 @@ impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {
 
     pub fn draw_line(&mut self, start: [f32; 3], end: [f32; 3], color: [f32; 4]) {
         self.line_renderer.draw_line(start, end, color);
+    }
+
+    pub fn draw_marker(&mut self, position: [f32; 3], size: f32, color: [f32; 4]) {
+        self.line_renderer.draw_line(vec3_add(position, [size, 0.0, 0.0]),
+                                     vec3_add(position, [-size, 0.0, 0.0]),
+                                     color);
+
+        self.line_renderer.draw_line(vec3_add(position, [0.0, size, 0.0]),
+                                     vec3_add(position, [0.0, -size, 0.0]),
+                                     color);
+
+        self.line_renderer.draw_line(vec3_add(position, [0.0, 0.0, size]),
+                                     vec3_add(position, [0.0, 0.0, -size]),
+                                     color);
     }
 
     pub fn draw_text_on_screen (
@@ -80,6 +159,25 @@ impl<R: gfx::Resources, F: Factory<R>> DebugRenderer<R, F> {
         stream: &mut S,
         projection: [[f32; 4]; 4],
     ) -> Result<(), DebugRendererError> {
+
+        loop {
+            match CommandQueue::instance().pop_front() {
+                Some(DrawCommand::DrawLine(start, end, color)) => {
+                    self.draw_line(start, end, color);
+                },
+                Some(DrawCommand::DrawMarker(position, size, color)) => {
+                    self.draw_marker(position, size, color);
+                },
+                Some(DrawCommand::DrawScreenText(ref text, position, color)) => {
+                    self.draw_text_on_screen(&text, position, color);
+                },
+                Some(DrawCommand::DrawWorldText(ref text, position, color)) => {
+                    self.draw_text_at_position(&text, position, color);
+                }
+                None => break
+            }
+        }
+
         try!(self.line_renderer.render(stream, &mut self.factory, projection));
         try!(self.text_renderer.draw_end_at(stream, projection));
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
 #[macro_use]
 extern crate gfx;
 extern crate gfx_text;
+extern crate vecmath;
 
 mod debug_renderer;
 mod line_renderer;
 mod utils;
 
-pub use debug_renderer::{DebugRenderer, DebugRendererError};
+pub use debug_renderer::{DebugRenderer,
+                         DebugRendererError,
+                         draw_line,
+                         draw_text_on_screen,
+                         draw_text_at_position,
+                         draw_marker};


### PR DESCRIPTION
Added `gfx_debug_draw::draw_*` methods which push draw commands to a shared, static CommandQueue instance. Otherwise, DebugRenderer is awkward to use for actual debugging without the DebugRenderer instance being accessible in every foreseeable context.
