### PR TITLE
Bump gfx_text version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 
 gfx = "0.6.*"
-gfx_text = "0.2.*"
+gfx_text = "^0.3.1"
 vecmath = "*"
 
 ###### For example ###########################


### PR DESCRIPTION
This fixes build issues regarding conflicting freetype-sys versions.

This should fix broken build in #44. So you may merge this at first, rerun build for #44 and merge that.
