### PR TITLE
Updated gfx_text dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gfx_debug_draw"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Steve Jahns <s.t.jahns@gmail.com>"]
 keywords = ["draw", "gfx", "debug", "piston"]
 description = "Debug rendering library for gfx-rs"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 
 gfx = "0.8.0"
-gfx_text = "^0.7.0"
+gfx_text = "0.8.0"
 vecmath = "0.2.0"
 
 ###### For example ###########################


### PR DESCRIPTION
Forgot to update gfx_text.
- Bumped to 0.9.1
- Yank 0.9.0
