### PR TITLE
Fixing a typo in fragment shader

### DIFF
--- a/src/line_renderer.rs
+++ b/src/line_renderer.rs
@@ -58,7 +58,7 @@ impl<R: gfx::Resources> LineRenderer<R> {
             let init = pipe::Init {
                 vbuf: (),
                 u_model_view_proj: "u_model_view_proj",
-                out_color: ("o_Color", format, gfx::state::ColorMask::all(), Some(gfx::preset::blend::ALPHA)),
+                out_color: ("out_color", format, gfx::state::ColorMask::all(), Some(gfx::preset::blend::ALPHA)),
                 out_depth: gfx::preset::depth::LESS_EQUAL_WRITE,
             };
             let pso = try!(factory.create_pipeline_state(


### PR DESCRIPTION
Fixing a typo in fragment shader preventing the library from work under
Linux (at least under NVidia card + proprietary driver).